### PR TITLE
add link to v3 python client project

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,11 @@
 README
 ==============================================================================
 
-This is a python interface for the Openshift v2 REST API.  Check 
+This is a python interface for the OpenShift v2 REST API.  Check 
 oshift/__init__.py for the class file.
+
+For OpenShift v3 and above, please go to
+https://github.com/openshift/openshift-restclient-python
 
 [2012-11-19]
 Use python requests module instead of httplib for a cleaner interface.  


### PR DESCRIPTION
Searching for openshift client python in duckduckgo resulted in showing this project at a high position. I think adding a link to the interesting v3 project makes sense. Similar to how it is done with Java client projects.